### PR TITLE
Utiliser des centilitres au lieu des litres

### DIFF
--- a/go_with_the_flow.ino
+++ b/go_with_the_flow.ino
@@ -16,8 +16,8 @@ void setup() {
 }
 
 void loop() {
-  double liters = pulses / 450.0;
-  display_liters.showNumberDecEx(liters * 100, 0b01000000 );
+  double centiliters = pulses / 4.5;
+  display_liters.showNumberDecEx(centiliters, 0b01000000);
 }
 
 void countPulses() {


### PR DESCRIPTION
C'est pas un gros changement, mais ça démontre un moyen de réduire les risques de perte de précision (en divisant puis en re-multipliant), et ça élimine une opération (une multiplication en float, c'est lourd sur un microcontrôleur).

Réalistement, ça change probablement presque rien dans la précision du résultat, vu que le calcul est pas cumulatif. En performance, c'est probablement pas visible non plus dans quelque chose d'aussi petit.

Mais hey, j'me suis dit... pourquoi pas un peu d'optimisation prématurée pour terminer la soirée? :p